### PR TITLE
fixes for v6.2

### DIFF
--- a/js/angular.js
+++ b/js/angular.js
@@ -568,9 +568,9 @@ $scope.hasBossKey = function(dungeon) {
       var bottles = 0;
       var hasLetter = false;
       for (var i = 0; i < $scope.currentItemsAll.length; i++) {
-        if ($scope.currentItemsAll[i].startsWith('Bottle')) {
+        if ($scope.currentItemsAll[i].startsWith('Bottle') || $scope.currentItemsAll[i].startsWith('Rutos')) {
           bottles++;
-          if ($scope.currentItemsAll[i] == 'Bottle with Letter') {
+          if ($scope.currentItemsAll[i] == 'Rutos Letter') {
             hasLetter = true;
           }
         }
@@ -940,6 +940,17 @@ $scope.hasBossKey = function(dungeon) {
     if (typeof logfile == 'string') {
       logfile = JSON.parse(logfile);
     }
+
+    if (logfile['entrances'] === undefined) logfile['entrances'] = {};
+    if (logfile['entrances']['Child Spawn -> KF Links House'] === undefined){
+      logfile['entrances']['Child Spawn -> KF Links House'] = defaultSpawns['Child'];
+      checked_child_spawn = true;
+    }
+    if (logfile['entrances']['Adult Spawn -> Temple of Time'] === undefined){
+      logfile['entrances']['Adult Spawn -> Temple of Time'] = defaultSpawns['Adult'];
+      checked_adult_spawn = true;
+    }
+
     $scope.currentSpoilerLog = logfile;
     //if (logfile['settings']['entrance_shuffle'] != "off") {
     //  alert("Error! Entrance shuffle is not supported.");
@@ -955,8 +966,8 @@ $scope.hasBossKey = function(dungeon) {
 
     var spawn_age = logfile['randomized_settings']['starting_age'];
 
-    checked_child_spawn = spawn_age == 'child' ? true : false;
-    checked_adult_spawn = spawn_age == 'adult' ? true : false;
+    checked_child_spawn = spawn_age == 'child' ? true : checked_child_spawn;
+    checked_adult_spawn = spawn_age == 'adult' ? true : checked_adult_spawn;
 
     try {
       $scope.currentSeed = logfile[':seed'];
@@ -968,7 +979,7 @@ $scope.hasBossKey = function(dungeon) {
 
       $scope.child_spawn = childRegion;
       child_spawn = childRegion;
-      $scope.child_spawn_text = logfile['randomized_settings']['starting_age'] == 'child' ? childRegionText : '???';      
+      $scope.child_spawn_text = (logfile['randomized_settings']['starting_age'] == 'child' || checked_child_spawn) ? childRegionText : '???';
       child_spawn_text = childRegionText;
 
       var adultRegion = logfile['entrances']['Adult Spawn -> Temple of Time']['region'] === undefined ? logfile['entrances']['Adult Spawn -> Temple of Time'] : logfile['entrances']['Adult Spawn -> Temple of Time']['region'];
@@ -979,7 +990,7 @@ $scope.hasBossKey = function(dungeon) {
       adult_spawn = adultRegion;
       adult_spawn_text = adultRegionText;
       //$scope.adult_spawn_text = logfile['randomized_settings']['starting_age'] == 'adult' ? logfile['entrances']['Adult Spawn -> Temple of Time']['region'] : '???';
-      $scope.adult_spawn_text = logfile['randomized_settings']['starting_age'] == 'adult' ? adultRegionText : '???';;
+      $scope.adult_spawn_text = (logfile['randomized_settings']['starting_age'] == 'adult' || checked_adult_spawn) ? adultRegionText : '???';
       var results = logfile['locations'];
       $scope.fsHash = logfile['file_hash'];
       $scope.isShopsanity = logfile['settings']['shopsanity'] != 'off';
@@ -1016,6 +1027,9 @@ $scope.hasBossKey = function(dungeon) {
       $scope.itemCounts['Gold Skulltula Token'] = 0;
       $scope.itemCounts['Kokiri Sword'] = 0;
       $scope.itemCounts['Nayrus Love'] = 0;
+      for (var item in logfile['starting_items']) {
+        $scope.itemCounts[item] = logfile['starting_items'][item];
+      }
       for (var hint in logfile['gossip_stones']) {
         region = hint.split('(')[0].trim();
         if (region == 'Zoras River') region = 'Zora River';
@@ -1242,7 +1256,7 @@ var shopItemImages = {
   'Bottle with Fairy': 'fairy.png',
   'Bottle with Fish': 'fish.png',
   'Bottle with Green Potion': 'greenpotion.png',
-  'Bottle with Letter': 'bottle-letter.png',
+  'Rutos Letter': 'bottle-letter.png',
   'Bottle with Milk': 'milk.png',
   'Bottle with Poe': 'poe.png',
   'Bottle with Red Potion': 'redpotion.png',

--- a/js/static.js
+++ b/js/static.js
@@ -16,7 +16,7 @@ var importantItems = [
   'Ocarina of Time',
   'Ocarina',
   'Bottle',
-  'Bottle with Letter',
+  'Rutos Letter',
   'Bottle with Milk',
   'Bottle with Red Potion',
   'Bottle with Green Potion',
@@ -915,7 +915,7 @@ var locationsByRegionAdult = {
   "Desert Colossus": ["Colossus Freestanding PoH", "Colossus Great Fairy Reward", "Sheik at Colossus"],
   "Spirit Temple": ["Spirit Temple Child Climb North Chest", "Spirit Temple Child Climb East Chest", "Spirit Temple Map Chest", "Spirit Temple Sun Block Room Chest", "Spirit Temple Silver Gauntlets Chest", "Spirit Temple Compass Chest", "Spirit Temple Early Adult Right Chest", "Spirit Temple First Mirror Left Chest", "Spirit Temple First Mirror Right Chest", "Spirit Temple Statue Room Northeast Chest", "Spirit Temple Statue Room Hand Chest", "Spirit Temple Near Four Armos Chest", "Spirit Temple Hallway Right Invisible Chest", "Spirit Temple Hallway Left Invisible Chest", "Spirit Temple Mirror Shield Chest", "Spirit Temple Boss Key Chest", "Spirit Temple Topmost Chest", "Spirit Temple Twinrova Heart", "Twinrova"],
   "Kakariko Village": ["Song from Windmill", "Sheik in Kakariko", "Kak Anju as Adult", "Kak Impas House Freestanding PoH", "Kak Windmill Freestanding PoH", "Kak Man on Roof", "Kak Open Grotto Chest", "Kak Redead Grotto Chest", "Kak Shooting Gallery Reward", "Kak 10 Gold Skulltula Reward", "Kak 20 Gold Skulltula Reward", "Kak 30 Gold Skulltula Reward", "Kak 40 Gold Skulltula Reward", "Kak 50 Gold Skulltula Reward"],
-  "Graveyard": ["Song from Royal Familys Tomb", "Graveyard Shield Grave Chest", "Graveyard Heart Piece Grave Chest", "Graveyard Royal Familys Tomb Chest", "Graveyard Freestanding PoH", "Graveyard Hookshot Chest", "Graveyard Dampe Race Freestanding PoH"],
+  "Graveyard": ["Song from Royal Familys Tomb", "Graveyard Shield Grave Chest", "Graveyard Heart Piece Grave Chest", "Graveyard Royal Familys Tomb Chest", "Graveyard Freestanding PoH", "Graveyard Dampe Race Hookshot Chest", "Graveyard Dampe Race Freestanding PoH"],
   "Shadow Temple": ["Shadow Temple vanilla", "Shadow Temple Map Chest", "Shadow Temple Hover Boots Chest", "Shadow Temple Compass Chest", "Shadow Temple Early Silver Rupee Chest", "Shadow Temple Invisible Blades Visible Chest", "Shadow Temple Invisible Blades Invisible Chest", "Shadow Temple Falling Spikes Lower Chest", "Shadow Temple Falling Spikes Upper Chest", "Shadow Temple Falling Spikes Switch Chest", "Shadow Temple Invisible Spikes Chest", "Shadow Temple Freestanding Key", "Shadow Temple Wind Hint Chest", "Shadow Temple After Wind Enemy Chest", "Shadow Temple After Wind Hidden Chest", "Shadow Temple Spike Walls Left Chest", "Shadow Temple Boss Key Chest", "Shadow Temple Invisible Floormaster Chest", "Shadow Temple Bongo Bongo Heart", "Bongo Bongo"],
   "Death Mountain Trail": ["DMT Freestanding PoH", "DMT Chest", "DMT Storms Grotto Chest", "DMT Great Fairy Reward", "DMT Biggoron"],
   "Death Mountain Crater": ["DMC Volcano Freestanding PoH", "DMC Wall Freestanding PoH", "DMC Upper Grotto Chest", "DMC Great Fairy Reward", "Sheik in Crater"],
@@ -927,7 +927,7 @@ var locationsByRegionAdult = {
   "Zoras Fountain": ["ZF Iceberg Freestanding PoH", "ZF Bottom Freestanding PoH", "ZF Great Fairy Reward"],
   "Ice Cavern": ["Ice Cavern Map Chest", "Ice Cavern Compass Chest", "Ice Cavern Freestanding PoH", "Ice Cavern Iron Boots Chest", "Sheik in Ice Cavern"],
   "Outside Ganons Castle": ["OGC Great Fairy Reward"],
-  "Ganons Castle": ["Ganons Castle Forest Trial Chest", "Ganons Castle Water Trial Left Chest", "Ganons Castle Water Trial Right Chest", "Ganons Castle Shadow Trial Front Chest", "Ganons Castle Shadow Trial Golden Gauntlets Chest", "Ganons Castle Light Trial First Left Chest", "Ganons Castle Light Trial Second Left Chest", "Ganons Castle Light Trial Third Left Chest", "Ganons Castle Light Trial First Right Chest", "Ganons Castle Light Trial Second Right Chest", "Ganons Castle Light Trial Third Right Chest", "Ganons Castle Light Trial Invisible Enemies Chest", "Ganons Castle Light Trial Lullaby Chest", "Ganons Castle Spirit Trial Crystal Switch Chest", "Ganons Castle Spirit Trial Invisible Chest", "Ganons Tower Boss Key Chest"]
+  "Ganons Castle": ["Ganons Castle Forest Trial Chest", "Ganons Castle Water Trial Left Chest", "Ganons Castle Water Trial Right Chest", "Ganons Castle Shadow Trial Front Chest", "Ganons Castle Shadow Trial Golden Gauntlets Chest", "Ganons Castle Light Trial First Left Chest", "Ganons Castle Light Trial Second Left Chest", "Ganons Castle Light Trial Third Left Chest", "Ganons Castle Light Trial First Right Chest", "Ganons Castle Light Trial Second Right Chest", "Ganons Castle Light Trial Third Right Chest", "Ganons Castle Light Trial Invisible Enemies Chest", "Ganons Castle Light Trial Lullaby Chest", "Ganons Castle Spirit Trial Crystal Switch Chest", "Ganons Castle Spirit Trial Invisible Chest", "Ganons Tower Boss Key Chest", "Light Arrows Hint", "Ganon"]
 };
 
 var skulltulasByRegionAdult = {
@@ -1048,6 +1048,11 @@ var spawnsByRegion = {
     "Zoras Fountain":                ['Zoras Fountain', 'ZF Great Fairy Fountain'],
     "Outside Ganons Castle":         ['OGC Great Fairy Fountain'],
 }
+
+var defaultSpawns = {
+  'Child': 'KF Links House',
+  'Adult': 'Temple of Time'
+};
 
 function getSpawn(spawnFromLog) {
   var region;


### PR DESCRIPTION
Various fixes to get this to work with the latest spoiler log format. I tested against the Season 6 preset and just ran through a seed, fixing bugs as I encountered them. No guarantees that it works for EVERY seed (especially on different settings), but this was a quick attempt to get this viable for Season 6 practice.

* Parse new log entrance format (non-random spawns seem to be missing from the entrance table)
* Fix Ruto's Letter (broken due to rename from `Bottle With Letter`) [fixes FantaTanked/zootr-sim-offline/issues/5]
* Attempt to start with default equipment (i.e. Deku Shield and Ocarina for S6, but probably works for most things)
* Fix missing Hookshot chest from Dampe (looks like the check was renamed)
* Add `Ganon` and `Light Arrows Hint` back to Ganon's Castle (not sure why they were gone, but they seem functional once I added them back to the list)